### PR TITLE
Fix fourkeys mode for Frue derived ROMs + VIP Card/Door Key naming fix

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -6423,7 +6423,7 @@ def make_four_keys():
             assert 1 <= opcode <= 6 or opcode == 0x40
             key_index = script.script[0][2][0]
             key = ItemObject.get(key_index)
-            if key.name in ['Door Key', 'VIP Card']:
+            if key.name.upper() in ['DOOR KEY', 'VIP CARD']:
                 continue
             key.set_name('Useless key')
             locations = [loc for loc in keydict if key in keydict[loc]]

--- a/randomizer.py
+++ b/randomizer.py
@@ -6423,6 +6423,8 @@ def make_four_keys():
             assert 1 <= opcode <= 6 or opcode == 0x40
             key_index = script.script[0][2][0]
             key = ItemObject.get(key_index)
+            if key.name in ['Door Key', 'VIP Card']:
+                continue
             key.set_name('Useless key')
             locations = [loc for loc in keydict if key in keydict[loc]]
             if not locations:
@@ -6874,9 +6876,14 @@ ALL_OBJECTS = [g for g in globals().values()
 
 
 def get_keydict():
-    tower = {'sky', 'wind', 'cloud', 'light', 'trial', 'truth', 'narcysus'}
+    frue = bool(re.search(r'FRUE|KUREJI|SPEKKIO', get_global_label()))
+    narcysus_name = 'sacral' if frue else 'narcysus'
+    gratze_name = 'jail' if frue else 'basement'
+    dankirk_name = 'angel' if frue else 'dankirk'
+                     
+    tower = {'sky', 'wind', 'cloud', 'light', 'trial', 'truth', narcysus_name}
     shrine = {'sword', 'heart', 'ghost'}
-    dungeon = {'lake', 'ruby', 'dankirk', 'basement', 'ancient'}
+    dungeon = {'lake', 'ruby', 'ancient', dankirk_name, gratze_name}
     mountain = {'magma', 'flower', 'tree'}
 
     keys = lange(0x1af, 0x1c0) + [0x1c2]


### PR DESCRIPTION
* Frue derived ROMs use a different name for the Basement, Dankirk, and Narcysus keys which wasn't accounted for in four keys generation, which caused assertion failures.
* Stop Door Key and VIP Card being renamed to 'Useless key':
  * VIP Card isn't a key and still works for the VIP room at Markao, so still useful
  * Door Key is given by default, so while it doesn't matter that much, 'Useless key' shows up in the Scenario screen otherwise:
![image](https://github.com/abyssonym/terrorwave/assets/80146830/e6ee4f61-6119-4583-9e92-8ff3a147fff0)

